### PR TITLE
fix: resolve ENOENT crash by including package.json in final image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ WORKDIR /app
 # Copy the build output and node_modules from the builder stage
 COPY --from=builder /app/build /app/build
 COPY --from=builder /app/node_modules /app/node_modules
+COPY --from=builder /app/package.json /app/package.json
 
 # Set environment variables (the API key should be set as an environment variable at runtime)
 ENV NODE_ENV=production


### PR DESCRIPTION
When starting the container, the application attempts to read package.json, which was previously excluded from the final runner stage in the multi-stage Dockerfile.

This commit introduces "COPY --from=builder /app/package.json /app/package.json" to the runner stage. This explicitly satisfies the runtime file dependency to ensure a successful container startup.