### PR TITLE
fix: align npm provenance with renamed repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/BurtTheCoder/mcp-virustotal.git"
+    "url": "git+https://github.com/w0h1v/mcp-virustotal.git"
   },
   "dependencies": {
     "axios": "1.20.0",

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.BurtTheCoder/virustotal",
   "description": "MCP server for querying VirusTotal API with comprehensive security analysis tools.",
   "repository": {
-    "url": "https://github.com/BurtTheCoder/mcp-virustotal",
+    "url": "https://github.com/w0h1v/mcp-virustotal",
     "source": "github"
   },
   "version": "1.0.27",


### PR DESCRIPTION
Publishing fails after the repository moved to w0h1v/mcp-virustotal. Update package.json and server.json repository URLs to the current GitHub location so npm provenance matches the publishing workflow identity.

The npm package name and MCP registry identifier remain unchanged. The corresponding npm trusted-publisher connection is being replaced with w0h1v/mcp-virustotal and npm-publish.yml.

Validation: git diff --check and npm pack --dry-run passed. This changes repository metadata only; the dependency update was already tested in PR #20.
