### PR TITLE
fix: include hashes for IP-related files

### DIFF
--- a/src/formatters/ip.ts
+++ b/src/formatters/ip.ts
@@ -78,6 +78,7 @@ export function formatRelationshipData(relType: string, item: any): string {
     case 'communicating_files':
     case 'downloaded_files':
       return `  • ${attrs.meaningful_name || item.id}
+    SHA-256: ${item.id}
     Type: ${attrs.type_description || attrs.type || 'Unknown'}
     First Seen: ${attrs.first_submission_date ? formatDateTime(attrs.first_submission_date) : 'Unknown'}`;
 

--- a/tests/formatters.test.mjs
+++ b/tests/formatters.test.mjs
@@ -10,6 +10,7 @@ import {
   formatFileResults,
   formatUrlScanResults,
   formatIpResults,
+  formatIpRelationshipItem,
   formatDomainResults,
   formatDetectionResults,
   formatDateTime,
@@ -176,6 +177,21 @@ test('formatIpResults: minimal', () => {
   const out = formatIpResults({ id: '1.1.1.1', attributes: {} });
   assert.match(out.text, /IP Address Analysis/);
   assert.match(out.text, /1.1.1.1/);
+});
+
+test('formatIpRelationshipItem: related files include their SHA-256', () => {
+  const sha256 = '351386fb69cc2e985d2a92fd64353267e4ee8cb6ae2f4c8f7850850be8c73c93';
+  const out = formatIpRelationshipItem('communicating_files', {
+    id: sha256,
+    attributes: {
+      meaningful_name: 'sample.exe',
+      type_description: 'Win32 EXE',
+      first_submission_date: 1731456000,
+    },
+  });
+
+  assert.match(out, /sample\.exe/);
+  assert.match(out, new RegExp(`SHA-256: ${sha256}`));
 });
 
 test('formatDomainResults: minimal', () => {


### PR DESCRIPTION
## Summary

Include each related file's SHA-256 in IP relationship output, even when VirusTotal provides a human-readable filename.

## Changes Made

- Render the VirusTotal file object ID as `SHA-256` for `communicating_files` and `downloaded_files`.
- Add regression coverage for a related file that has both a meaningful name and a SHA-256 object ID.

## Test Plan

- `npm test` (18 tests passed)
